### PR TITLE
chore(ci): Run a single tox-uv job, drop Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,16 +32,18 @@ jobs:
     name: Build & verify package
     runs-on: ubuntu-latest
 
+    permissions:
+      attestations: write
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - uses: hynek/build-and-inspect-python-package@v2
-        id: baipp
-
-    outputs:
-      python-versions: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
+        with:
+          attest-build-provenance-github: ${{ github.event_name != 'pull_request' }}
 
   tox:
     name: Tests on ${{ matrix.os }}
@@ -79,7 +81,7 @@ jobs:
     environment: "Package deployment"
     needs: [tox]
     permissions:
-      # Required for trusted publishing
+      attestations: write
       id-token: write
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,20 +43,14 @@ jobs:
     outputs:
       python-versions: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
 
-  tests:
-    name: Tests on ${{ matrix.python-version }} (${{ matrix.os }})
+  tox:
+    name: Tests on ${{ matrix.os }}
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
-        python-version: ${{ fromJson(needs.build.outputs.python-versions) }}
-        include:
-          - os: macos-latest
-            python-version: 3
-          - os: windows-latest
-            python-version: 3
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
 
     steps:
       - name: Download packages
@@ -65,57 +59,25 @@ jobs:
           name: Packages
           path: dist/
       - run: tar xf dist/*.tar.gz --strip-components=1
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-          cache: pip
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
-      - name: Update pip
-        run: pip install --upgrade pip
+      - uses: astral-sh/setup-uv@v5
 
       - name: Install tox
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox tox-gh-actions
+          uv tool install --with=tox-uv tox
       - name: Show tox config
         run: tox c
       - name: Run tox
-        run: tox -v --exit-and-dump-after 1200 run --installpkg dist/*.whl
+        run: tox -v --exit-and-dump-after 60 --parallel --installpkg dist/*.whl
 
       - uses: codecov/codecov-action@v5
         if: ${{ always() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  checks:
-    name: Checks
-    needs: build
-    runs-on: 'ubuntu-latest'
-    continue-on-error: true
-    strategy:
-      matrix:
-        check: ['style', 'typecheck', 'spellcheck']
-
-    steps:
-      - name: Download pre-built packages
-        uses: actions/download-artifact@v4
-        with:
-          name: Packages
-          path: dist
-      - run: tar xf dist/*.tar.gz --strip-components=1
-      - name: Show tox config
-        run: pipx run tox c
-      - name: Show tox config (this call)
-        run: pipx run tox c -e ${{ matrix.check }}
-      - name: Run check
-        run: pipx run tox -e ${{ matrix.check }}
-
   publish:
     runs-on: ubuntu-latest
     environment: "Package deployment"
-    needs: [tests]
+    needs: [tox]
     permissions:
       # Required for trusted publishing
       id-token: write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,17 @@ inline-quotes = "single"
 
 [tool.ruff.format]
 quote-style = "single"
+
+[tool.coverage.run]
+branch = true
+parallel = true
+omit = [
+  # Temporary zipimport module generated during tests
+  "*/mymodule.zip/*",
+]
+
+[tool.coverage.paths]
+source = [
+  "src/acres",
+  "**/site-packages/acres",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,13 @@ authors = [
 dependencies = [
   "importlib_resources >=5.7; python_version < '3.11'",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/src/acres/__init__.py
+++ b/src/acres/__init__.py
@@ -44,10 +44,7 @@ from functools import cached_property
 from pathlib import Path
 from types import ModuleType
 
-if sys.version_info >= (3, 9):
-    from functools import cache
-else:
-    from functools import lru_cache as cache
+from functools import cache
 
 if sys.version_info >= (3, 11):
     from importlib.resources import as_file, files

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,9 @@
 requires =
   tox>=4
 envlist =
+  clean
   py3{8,9,10,11,12,13}
+  report
   style
   typecheck
   spellcheck
@@ -36,13 +38,29 @@ pass_env =
   PYTHON_GIL
 deps =
   pytest
-  pytest-cov
+  coverage
+
+depends =
+  py3{8,9,10,11,12,13}: clean
+  report: py3{8,9,10,11,12,13}
 
 commands =
-  pytest -svx --doctest-modules \
-    --cov . --cov-report term --cov-report xml \
+  python -m coverage run -m pytest -svx --doctest-modules \
     --durations=20 --durations-min=1.0 \
     {posargs}
+
+[testenv:report]
+deps = coverage[toml]
+skip_install = true
+commands =
+  coverage combine
+  coverage report
+  coverage xml
+
+[testenv:clean]
+deps = coverage[toml]
+skip_install = true
+commands = coverage erase
 
 [testenv:style]
 description = Check our style guide

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
   tox>=4
 envlist =
   clean
-  py3{8,9,10,11,12,13}
+  py3{9,10,11,12,13}
   report
   style
   typecheck
@@ -13,7 +13,6 @@ skip_missing_interpreters = true
 # Configuration that allows us to split tests across GitHub runners effectively
 [gh-actions]
 python =
-  3.8: py38
   3.9: py39
   3.10: py310
   3.11: py311
@@ -41,8 +40,8 @@ deps =
   coverage
 
 depends =
-  py3{8,9,10,11,12,13}: clean
-  report: py3{8,9,10,11,12,13}
+  py3{9,10,11,12,13}: clean
+  report: py3{9,10,11,12,13}
 
 commands =
   python -m coverage run -m pytest -svx --doctest-modules \


### PR DESCRIPTION
With as small a test suite as this, multiple test jobs per OS is excessive. We can just run multiple Python versions in a single job with `tox-uv`.