### PR TITLE
type: Add acres.typ and acres.cache modules to reduce import-time costs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Show tox config
         run: tox c
       - name: Run tox
-        run: tox -v --exit-and-dump-after 60 --parallel --installpkg dist/*.whl
+        run: tox -v --exit-and-dump-after 60 --parallel-no-spinner --installpkg dist/*.whl
 
       - uses: codecov/codecov-action@v5
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install tox
         run: |
-          uv tool install --with=tox-uv tox
+          uv tool install -p 3.13 --with=tox-uv tox
       - name: Show tox config
         run: tox c
       - name: Run tox

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ which lets it play nicely with type checkers.
 
 `Loader.cached` uses a global cache. This ensures that cached files do not get
 unloaded if a `Loader()` instance is garbage collected, and it also ensures that
-instances created cheaply and garbage collected when out of scope.
+instances can be created cheaply and garbage collected when out of scope.
 
 ## Why acres?
 
@@ -134,6 +134,21 @@ this bug will only exhibit when the package is zipped.
 
 `acres.Loader` aims to clearly delineate the scopes and capabilities of
 the accessed resources, including providing an interpreter-lifetime scope.
+
+## Type annotations
+
+`acres` is fully type-annotated, and checked with both `mypy` and `pyright`.
+The `Loader.readable` method returns a [Traversable][], which moved from
+`importlib.abc` in Python 3.10 to `importlib.resources.abc` in Python 3.11.
+To simplify the use of this annotation in functions that accept readable
+resources, use:
+
+```python
+import acres.typ as at
+
+def myfunc(resource: at.Traversable) -> ReturnType:
+    ...
+```
 
 [Traversable]: https://docs.python.org/3/library/importlib.resources.abc.html#importlib.resources.abc.Traversable
 [pathlib.Path]: https://docs.python.org/3/library/pathlib.html#pathlib.Path

--- a/changelog.d/20250528_124546_markiewicz_typ_module.md
+++ b/changelog.d/20250528_124546_markiewicz_typ_module.md
@@ -1,0 +1,51 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Added
+
+- An `acres.typ` module is added for providing access to the types
+  accepted by or returned by `acres.Loader` and its methods.
+  Use `acres.typ.Traversable` to annotate types without checking
+  Python versions for its location.
+  Use `from __future__ import annotations` to avoid unnecessary imports
+  in Python 3.13 and lower.
+
+### Changed
+
+- The `importlib_resources` backport is no longer a dependency, even
+  for older Python versions.
+
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,8 @@ source = [
   "src/acres",
   "**/site-packages/acres",
 ]
+
+[tool.coverage.report]
+exclude_also = [
+  "if.*TYPE_CHECKING:",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,7 @@ description = "Access resources on your terms"
 authors = [
   {name = "The NiPreps Developers", email = "nipreps@gmail.com"}
 ]
-dependencies = [
-  "importlib_resources >=5.7; python_version < '3.11'",
-]
+dependencies = []
 requires-python = ">=3.9"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ description = "Access resources on your terms"
 authors = [
   {name = "The NiPreps Developers", email = "nipreps@gmail.com"}
 ]
-dependencies = []
+dependencies = [
+  "importlib_resources >=5.7; python_version < '3.10'",
+]
 requires-python = ">=3.9"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/acres/__init__.py
+++ b/src/acres/__init__.py
@@ -62,7 +62,7 @@ atexit.register(EXIT_STACK.close)
 
 
 @cache
-def _cache_resource(anchor: str | ModuleType, segments: tuple[str]) -> Path:
+def _cache_resource(anchor: str | ModuleType, segments: tuple[str, ...]) -> Path:
     # PY310(importlib_resources): no-any-return, PY311+(importlib.resources): unused-ignore
     return EXIT_STACK.enter_context(as_file(files(anchor).joinpath(*segments)))  # type: ignore[no-any-return,unused-ignore]
 
@@ -203,7 +203,6 @@ class Loader:
         requested separately may result in some duplication.
         """
         # Use self._anchor and segments to ensure the cache does not depend on id(self.files)
-        # PY310(importlib_resources): unused-ignore, PY311+(importlib.resources) arg-type
-        return _cache_resource(self._anchor, segments)  # type: ignore[arg-type,unused-ignore]
+        return _cache_resource(self._anchor, segments)
 
     __call__ = cached

--- a/src/acres/__init__.py
+++ b/src/acres/__init__.py
@@ -126,7 +126,7 @@ class Loader:
         non-public means has a `.` or `_` prefix or is a 'tests'
         directory.
         """
-        from importlib.resources import files
+        from ._compat import files
 
         top_level = sorted(
             f'{p.name}/' if p.is_dir() else p.name
@@ -152,7 +152,7 @@ class Loader:
         This result is not cached or copied to the filesystem in cases where
         that would be necessary.
         """
-        from importlib.resources import files
+        from ._compat import files
 
         return files(self._anchor).joinpath(*segments)
 
@@ -165,7 +165,7 @@ class Loader:
         This result is not cached, and any temporary files that are created
         are deleted when the context is exited.
         """
-        from importlib.resources import as_file, files
+        from ._compat import as_file, files
 
         return as_file(files(self._anchor).joinpath(*segments))
 

--- a/src/acres/__init__.py
+++ b/src/acres/__init__.py
@@ -39,19 +39,15 @@ from __future__ import annotations
 
 import atexit
 import sys
-from contextlib import AbstractContextManager, ExitStack
-from functools import cached_property
-from pathlib import Path
-from types import ModuleType
+from contextlib import ExitStack
+from functools import cache, cached_property
 
-from functools import cache
+from . import typ as t
 
 if sys.version_info >= (3, 11):
     from importlib.resources import as_file, files
-    from importlib.resources.abc import Traversable
 else:
     from importlib_resources import as_file, files
-    from importlib_resources.abc import Traversable
 
 __all__ = ['Loader']
 
@@ -62,7 +58,7 @@ atexit.register(EXIT_STACK.close)
 
 
 @cache
-def _cache_resource(anchor: str | ModuleType, segments: tuple[str, ...]) -> Path:
+def _cache_resource(anchor: str | t.ModuleType, segments: tuple[str, ...]) -> t.Path:
     # PY310(importlib_resources): no-any-return, PY311+(importlib.resources): unused-ignore
     return EXIT_STACK.enter_context(as_file(files(anchor).joinpath(*segments)))  # type: ignore[no-any-return,unused-ignore]
 
@@ -139,7 +135,7 @@ class Loader:
     .. automethod:: cached
     """
 
-    def __init__(self, anchor: str | ModuleType):
+    def __init__(self, anchor: str | t.ModuleType):
         self._anchor = anchor
         self.files = files(anchor)
         # Allow class to have a different docstring from instances
@@ -168,7 +164,7 @@ class Loader:
 
         return '\n'.join(doclines)
 
-    def readable(self, *segments: str) -> Traversable:
+    def readable(self, *segments: str) -> t.Traversable:
         """Provide read access to a resource through a Path-like interface.
 
         This file may or may not exist on the filesystem, and may be
@@ -180,7 +176,7 @@ class Loader:
         # PY310(importlib_resources): no-any-return, PY311+(importlib.resources): unused-ignore
         return self.files.joinpath(*segments)  # type: ignore[no-any-return,unused-ignore]
 
-    def as_path(self, *segments: str) -> AbstractContextManager[Path]:
+    def as_path(self, *segments: str) -> t.AbstractContextManager[t.Path]:
         """Ensure data is available as a :class:`~pathlib.Path`.
 
         This method generates a context manager that yields a Path when
@@ -192,7 +188,7 @@ class Loader:
         # PY310(importlib_resources): no-any-return, PY311+(importlib.resources): unused-ignore
         return as_file(self.files.joinpath(*segments))  # type: ignore[no-any-return,unused-ignore]
 
-    def cached(self, *segments: str) -> Path:
+    def cached(self, *segments: str) -> t.Path:
         """Ensure data resource is available as a :class:`~pathlib.Path`.
 
         Any temporary files that are created remain available throughout

--- a/src/acres/_compat.py
+++ b/src/acres/_compat.py
@@ -1,0 +1,15 @@
+"""Compatibility module for importing the importlib.resources API.
+
+There is a bug in 3.9 handling of zip modules on Windows, so keep this
+around until the Python 3.9 end-of-life.
+"""
+
+import sys
+
+if sys.version_info >= (3, 10):
+    from importlib.resources import files, as_file
+else:
+    from importlib_resources import files, as_file
+
+
+__all__ = ['files', 'as_file']

--- a/src/acres/cache.py
+++ b/src/acres/cache.py
@@ -4,9 +4,8 @@ import atexit
 from contextlib import ExitStack
 from functools import cache
 
-import importlib.resources as res
-
 from . import typ as t
+from ._compat import files, as_file
 
 
 EXIT_STACK = ExitStack()
@@ -15,4 +14,4 @@ atexit.register(EXIT_STACK.close)
 
 @cache
 def cached_resource(anchor: str | t.ModuleType, segments: tuple[str, ...]) -> t.Path:
-    return EXIT_STACK.enter_context(res.as_file(res.files(anchor).joinpath(*segments)))
+    return EXIT_STACK.enter_context(as_file(files(anchor).joinpath(*segments)))

--- a/src/acres/cache.py
+++ b/src/acres/cache.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import atexit
+from contextlib import ExitStack
+from functools import cache
+
+import importlib.resources as res
+
+from . import typ as t
+
+
+EXIT_STACK = ExitStack()
+atexit.register(EXIT_STACK.close)
+
+
+@cache
+def cached_resource(anchor: str | t.ModuleType, segments: tuple[str, ...]) -> t.Path:
+    return EXIT_STACK.enter_context(res.as_file(res.files(anchor).joinpath(*segments)))

--- a/src/acres/typ.py
+++ b/src/acres/typ.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
         from importlib.abc import Traversable
 else:
 
-    def __getattr__(name: str) -> object:
+    def __getattr__(name: str) -> type:
         types = {
             'AbstractContextManager': 'contextlib',
             'Path': 'pathlib',

--- a/src/acres/typ.py
+++ b/src/acres/typ.py
@@ -37,13 +37,16 @@ The expected usage is::
 
 To get the runtime benefits of using this module, you should not import
 anything from it, but import the module and access symbols as attributes.
+For Python versions less than 3.14, `from __future__ import annotations`
+must be used to avoid eager loading of the types.
 
 The primary use for this in downstream tools is the
 :class:`~importlib.resources.abc.Traversable` type, which will be imported
-from ``importlib.resources`` or ``importlib_resources``, based on the Python
+from ``importlib.resources.abc`` or ``importlib.abc``, based on the Python
 version. However, other types that are not directly used in acres are also
 available.
 """
+
 import sys
 
 TYPE_CHECKING = False
@@ -55,7 +58,7 @@ if TYPE_CHECKING:
     if sys.version_info >= (3, 11):
         from importlib.resources.abc import Traversable
     else:
-        from importlib_resources.abc import Traversable
+        from importlib.abc import Traversable
 else:
 
     def __getattr__(name: str) -> object:
@@ -65,7 +68,7 @@ else:
             'ModuleType': 'types',
             'Traversable': 'importlib.resources.abc'
             if sys.version_info >= (3, 11)
-            else 'importlib_resources.abc',
+            else 'importlib.abc',
         }
         try:
             return getattr(__import__(types[name]), name)
@@ -74,7 +77,6 @@ else:
 
 
 __all__ = (
-    'TYPE_CHECKING',
     'AbstractContextManager',
     'ModuleType',
     'Path',

--- a/src/acres/typ.py
+++ b/src/acres/typ.py
@@ -1,0 +1,82 @@
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+#
+# This module was inspired by async_utils._typings:
+# https://github.com/mikeshardmind/async-utils/blob/7bf094f/src/async_utils/_typings.py
+#
+# This module was also licensed as Apache 2.
+"""Typing symbols for the acres package.
+
+This module aims to make the types used by the acres package available
+for type checking without requiring the original packages to be imported
+at runtime.
+
+The expected usage is::
+
+    import acres.typ as at
+
+    def resource_using_function(resource: at.Traversable) -> ReturnType:
+        ...
+
+To get the runtime benefits of using this module, you should not import
+anything from it, but import the module and access symbols as attributes.
+
+The primary use for this in downstream tools is the
+:class:`~importlib.resources.abc.Traversable` type, which will be imported
+from ``importlib.resources`` or ``importlib_resources``, based on the Python
+version. However, other types that are not directly used in acres are also
+available.
+"""
+import sys
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+    from pathlib import Path
+    from types import ModuleType
+
+    if sys.version_info >= (3, 11):
+        from importlib.resources.abc import Traversable
+    else:
+        from importlib_resources.abc import Traversable
+else:
+
+    def __getattr__(name: str) -> object:
+        types = {
+            'AbstractContextManager': 'contextlib',
+            'Path': 'pathlib',
+            'ModuleType': 'types',
+            'Traversable': 'importlib.resources.abc'
+            if sys.version_info >= (3, 11)
+            else 'importlib_resources.abc',
+        }
+        try:
+            return getattr(__import__(types[name]), name)
+        except KeyError:
+            raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
+
+
+__all__ = (
+    'TYPE_CHECKING',
+    'AbstractContextManager',
+    'ModuleType',
+    'Path',
+    'Traversable',
+)

--- a/src/acres/typ.py
+++ b/src/acres/typ.py
@@ -71,7 +71,7 @@ else:
             else 'importlib.abc',
         }
         try:
-            return getattr(__import__(types[name]), name)
+            return getattr(__import__(types[name], fromlist=['']), name)
         except KeyError:
             raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
 

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -1,19 +1,15 @@
-import sys
 from pathlib import Path
+import acres.typ as at
 from acres import Loader
-from .data import load_resource
 
-if sys.version_info >= (3, 11):
-    from importlib.resources.abc import Traversable
-else:
-    from importlib_resources.abc import Traversable
+from .data import load_resource
 
 
 def test_acres() -> None:
     assert isinstance(load_resource, Loader)
 
     text_resource = load_resource.readable('text_file')
-    assert isinstance(text_resource, Traversable)
+    assert isinstance(text_resource, at.Traversable)
     assert text_resource.read_text() == 'A file with some text.\n'
     # New object is created
     assert load_resource.readable('text_file') is not text_resource

--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,7 @@ labels = check
 deps =
   mypy
   pyright
+  importlib_resources
 skip_install = true
 commands =
   mypy --strict src tests

--- a/tox.ini
+++ b/tox.ini
@@ -97,7 +97,6 @@ labels = check
 deps =
   mypy
   pyright
-  importlib_resources
 skip_install = true
 commands =
   mypy --strict src tests


### PR DESCRIPTION
This PR grew out of a desire to reduce the impact (particularly at import time) of type annotations. So it does the following:

1) Imports that are only used for annotations are cordoned in `acres.typ`, which uses `TYPE_CHECKING`/`__getattr__` trickery to keep its own import time to a minimum. Imports only cost anything if the module attributes are fetched at runtime.
2) It moves the `ExitStack` into a separate `cache` module that is itself only imported when the `Loader.cache()` method is called.
3) It defers the `importlib.resources` import until `Loader()` is actually instantiated (creating the docstring is not deferrable).

Some types got fixed up along the way. `importlib.resources` vs `importlib_resources` is now only used for handling a Python 3.9 Windows bug. The API is otherwise consistent enough (and verified through tests) that we do not need to use the backported versions. The main thing we lose is the ability to use `Loader('library.submodule.data')` where `data` doesn't have an `__init__.py` in it, but that is quite a niche use-case.