### PR TITLE
feat: Default to not adding contents to docstring

### DIFF
--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,3 +1,3 @@
 from acres import Loader
 
-load_resource = Loader(__spec__.name)
+load_resource = Loader(__spec__.name, list_contents=True)

--- a/tests/test_data_module.py
+++ b/tests/test_data_module.py
@@ -38,3 +38,13 @@ def test_acres() -> None:
 def test_acres_docstring() -> None:
     assert load_resource.__doc__
     assert 'text_file' in load_resource.__doc__
+
+    throwaway = Loader('tests.data')
+    assert isinstance(throwaway.__doc__, str)
+    assert 'text_file' not in throwaway.__doc__
+    assert throwaway.readable('text_file').is_file()
+
+    throwaway = Loader('tests.data', list_contents=True)
+    assert isinstance(throwaway.__doc__, str)
+    assert 'text_file' in throwaway.__doc__
+    assert throwaway.readable('text_file').is_file()


### PR DESCRIPTION
If the goal is lightweight loaders, hitting the filesystem (and possibly eager-loading the bulky `importlib.resources`) to update the docstring is counterproductive. For the most part, this is used in `<package>.data` modules that make sense to document, but updating the docstring should be opt-in.

This is an API change, so needs to be a minor release.